### PR TITLE
docs: clarify GitHub App permissions and client ID setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For stronger security and higher rate limits, use a GitHub App:
    **Repository permissions** _(only required for `.github`/`.github-private` repo sync)_:
    - **Contents**: Read and write
    - **Workflows**: Read and write (required if syncing workflow files)
-   - **Pull requests**: Write
+   - **Pull requests**: Read and write
 
 2. Install it to your organization(s)
 3. Add `APP_CLIENT_ID` as a repository variable and `APP_PRIVATE_KEY` as a repository secret

--- a/README.md
+++ b/README.md
@@ -69,13 +69,18 @@ This sync is intentionally non-destructive: it creates or updates files present 
 For stronger security and higher rate limits, use a GitHub App:
 
 1. Create a GitHub App with the following permissions:
-   - **Organization Custom Properties**: Admin (required for managing custom property definitions)
-   - **Organization Administration**: Read and write (required for managing organization settings and rulesets)
-   - **Organization Issue Types**: Write (required for managing issue type definitions)
-   - **Organization Custom Roles**: Write (required for managing custom organization roles)
-   - **Custom Repository Roles**: Write (required for managing custom repository roles)
-   - **Contents**: Read and write (required for `.github`/`.github-private` repo sync)
-   - **Pull Requests**: Read and write (required for `.github`/`.github-private` repo sync)
+
+   **Organization permissions:**
+   - **Administration**: Read and write (required for managing organization settings and rulesets)
+   - **Custom properties**: Admin (required for managing custom property definitions)
+   - **Custom organization roles**: Write (required for managing custom organization roles)
+   - **Custom repository roles**: Write (required for managing custom repository roles)
+   - **Issue types**: Write (required for managing issue type definitions)
+
+   **Repository permissions** _(only required for `.github`/`.github-private` repo sync)_:
+   - **Contents**: Read and write
+   - **Workflows**: Read and write (required if syncing workflow files)
+   - **Pull requests**: Write
 2. Install it to your organization(s)
 3. Add `APP_ID` and `APP_PRIVATE_KEY` as repository secrets
 

--- a/README.md
+++ b/README.md
@@ -81,15 +81,16 @@ For stronger security and higher rate limits, use a GitHub App:
    - **Contents**: Read and write
    - **Workflows**: Read and write (required if syncing workflow files)
    - **Pull requests**: Write
+
 2. Install it to your organization(s)
-3. Add `APP_ID` and `APP_PRIVATE_KEY` as repository secrets
+3. Add `APP_CLIENT_ID` as a repository variable and `APP_PRIVATE_KEY` as a repository secret
 
 ```yml
 - name: Generate GitHub App Token
   id: app-token
   uses: actions/create-github-app-token@v3
   with:
-    app-id: ${{ secrets.APP_ID }}
+    client-id: ${{ vars.APP_CLIENT_ID }}
     private-key: ${{ secrets.APP_PRIVATE_KEY }}
     owner: ${{ github.repository_owner }}
 
@@ -1225,7 +1226,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ For stronger security and higher rate limits, use a GitHub App:
    - **Organization Custom Properties**: Admin (required for managing custom property definitions)
    - **Organization Administration**: Read and write (required for managing organization settings and rulesets)
    - **Organization Issue Types**: Write (required for managing issue type definitions)
+   - **Organization Custom Roles**: Write (required for managing custom organization roles)
+   - **Custom Repository Roles**: Write (required for managing custom repository roles)
    - **Contents**: Read and write (required for `.github`/`.github-private` repo sync)
    - **Pull Requests**: Read and write (required for `.github`/`.github-private` repo sync)
 2. Install it to your organization(s)


### PR DESCRIPTION
## Changes

- Restructure GitHub App permissions into separate **Organization permissions** and **Repository permissions** sections
- Use current GitHub App permission names:
  - Administration
  - Custom properties
  - Custom organization roles
  - Custom repository roles
  - Issue types
  - Contents
  - Workflows
  - Pull requests
- Document that repository permissions are only required for `.github` / `.github-private` repository sync
- Update GitHub App token examples to use `client-id: ${{ vars.APP_CLIENT_ID }}` instead of `app-id` / `APP_ID`
- Clarify that `APP_CLIENT_ID` should be stored as a repository variable and `APP_PRIVATE_KEY` as a repository secret

## Validation

- `npm run all`
